### PR TITLE
Fix minor (undetectable) bug in src/diet.cc

### DIFF
--- a/src/diet/main.cc
+++ b/src/diet/main.cc
@@ -62,12 +62,12 @@ optional<double> solve(int n, int m, vector<nut>& nuts, vector<food>& foods) {
     p.set_r(    i, SMALLER);
     p.set_b(    i, nuts[i].mx);
 
-    p.set_r(m + i, LARGER);
-    p.set_b(m + i, nuts[i].mn);
+    p.set_r(n + i, LARGER);
+    p.set_b(n + i, nuts[i].mn);
 
     for (int j = 0; j < m; ++j) {
       p.set_a(j,     i, foods[j].nuts[i]);
-      p.set_a(j, m + i, foods[j].nuts[i]);
+      p.set_a(j, n + i, foods[j].nuts[i]);
     }
   }
 


### PR DESCRIPTION
Fix the creation of the matrix A to add opposite sign inequalities at
an offset of i + n as opposed to i + m, because m denotes the number of
unknowns in the optimization problem and n the number of equations.

Coincidentally, the judge tests are weak enough to rate the source 100%
with n and m interchangeable in this context.
